### PR TITLE
duplicate   void update(ofEventArgs &e); definition in ofxOscReceiver.h

### DIFF
--- a/src/ofxOscReceiver.h
+++ b/src/ofxOscReceiver.h
@@ -91,8 +91,8 @@ private:
 	void grabMutex();
 	void releaseMutex();
     
-    ofxOscMessage currentMsg;
-    void update(ofEventArgs &e);
+  ofxOscMessage currentMsg;
+  void update(ofEventArgs &e);
 
 #ifdef TARGET_WIN32
 	// thread to listen with
@@ -107,8 +107,6 @@ private:
 #endif
 	// ready to be deleted
 	bool socketHasShutdown;
-    
-    void update(ofEventArgs &e);
 };
 
 #endif


### PR DESCRIPTION
At the end of the file you have a duplicate ofxOscReceiver.h.
This pull just remove it and thus allow compilation.
